### PR TITLE
Add dependabot automerge to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,17 +2,33 @@ name: Build and Test
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
       - synchronize
 
+permissions:
+  contents: write
+  pull-requests: write
+  packages: read
+  id-token: write
+
 jobs:
-  #delete this block if the repository you are creating is a PRO extension
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   build-test:
+    needs: authorize
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     secrets: inherit
     with:
       java: '[17, 21]'
 
+  dependabot:
+    needs: build-test
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Switch `pull_request` trigger to `pull_request_target` for proper permissions on dependabot PRs
- Add `authorize` job for security when using `pull_request_target`
- Add `dependabot` job that calls `liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main` after successful build
- Add required `permissions` block (`contents: write`, `pull-requests: write`, `packages: read`, `id-token: write`)

This aligns the workflow configuration with working extensions like `liquibase-mssql`, enabling automatic merge of patch/minor dependabot PRs after CI passes.

## Test plan
- [ ] Verify the workflow runs correctly on the next dependabot PR
- [ ] Confirm dependabot PRs get auto-approved and auto-merged for patch/minor updates